### PR TITLE
Add support for ES6 Symbols

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ function ownEnumerableKeys(obj) {
 	if (Object.getOwnPropertySymbols) {
 		keys = keys.concat(Object.getOwnPropertySymbols(obj));
 	}
-	return keys.filter(function (key) {
-		return Object.getOwnPropertyDescriptor(obj, key).enumerable;
+	return keys.filter(function(key) {
+		obj.propertyIsEnumerable(key);
 	});
 }
 

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ function ownEnumerableKeys(obj) {
 	if (Object.getOwnPropertySymbols) {
 		keys = keys.concat(Object.getOwnPropertySymbols(obj));
 	}
-	return keys.filter(function(key) {
-		obj.propertyIsEnumerable(key);
+	return keys.filter(function (key) {
+		return obj.propertyIsEnumerable(key);
 	});
 }
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,16 @@ function ToObject(val) {
 	return Object(val);
 }
 
+function ownEnumerableKeys(obj) {
+	var keys = Object.getOwnPropertyNames(obj);
+	if (Object.getOwnPropertySymbols) {
+		keys = keys.concat(Object.getOwnPropertySymbols(obj));
+	}
+	return keys.filter(function (key) {
+		return Object.getOwnPropertyDescriptor(obj, key).enumerable;
+	});
+}
+
 module.exports = Object.assign || function (target, source) {
 	var from;
 	var keys;
@@ -15,7 +25,7 @@ module.exports = Object.assign || function (target, source) {
 
 	for (var s = 1; s < arguments.length; s++) {
 		from = arguments[s];
-		keys = Object.keys(Object(from));
+		keys = ownEnumerableKeys(Object(from));
 
 		for (var i = 0; i < keys.length; i++) {
 			to[keys[i]] = from[keys[i]];

--- a/test.js
+++ b/test.js
@@ -66,13 +66,13 @@ it('should return the modified target object', function () {
 	assert.equal(returned, target);
 });
 
-if (typeof Symbol !== "undefined") {
+if (typeof Symbol !== 'undefined') {
 	it('should support symbol properties', function () {
 		var target = {};
 		var source = {};
-		var sym = Symbol("foo");
-		source[sym] = "bar";
+		var sym = Symbol('foo');
+		source[sym] = 'bar';
 		objectAssign(target, source);
-		assert.equal(target[sym], "bar");
+		assert.equal(target[sym], 'bar');
 	});
 }

--- a/test.js
+++ b/test.js
@@ -65,3 +65,14 @@ it('should return the modified target object', function () {
 	var returned = objectAssign(target, { a: 1 });
 	assert.equal(returned, target);
 });
+
+if (typeof Symbol !== "undefined") {
+	it('should support symbol properties', function () {
+		var target = {};
+		var source = {};
+		var sym = Symbol("foo");
+		source[sym] = "bar";
+		objectAssign(target, source);
+		assert.equal(target[sym], "bar");
+	});
+}


### PR DESCRIPTION
The [spec](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.assign) indicates that `Object.assign` should work for own enumerable symbol properties, along with string properties. I've added support for symbols. Works fine in environments without `Symbol`.