### PR TITLE
Support to getters and setters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ module.exports = Object.assign || function (target, source) {
 		keys = ownEnumerableKeys(Object(from));
 
 		for (var i = 0; i < keys.length; i++) {
-      var desc = Object.getOwnPropertyDescriptor(from, keys[i]);
-      Object.defineProperty(to, keys[i], desc);
+			var desc = Object.getOwnPropertyDescriptor(from, keys[i]);
+			Object.defineProperty(to, keys[i], desc);
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ module.exports = Object.assign || function (target, source) {
 		keys = ownEnumerableKeys(Object(from));
 
 		for (var i = 0; i < keys.length; i++) {
-			to[keys[i]] = from[keys[i]];
+      var desc = Object.getOwnPropertyDescriptor(from, keys[i]);
+      Object.defineProperty(to, keys[i], desc);
 		}
 	}
 


### PR DESCRIPTION
By using Object.getOwnPropertyDescriptor and Object.defineProperty we can actually copy getters and setters previously unsupported.

Such as:

```
var obj = {
    innerValue: 1,

    get v() {
        return this.innerValue;
    },

    set v(newValue) {
        this.innerValue = newValue;
    }
}; 
```