### PR TITLE
Replace ownEnumerableKeys with for-in loop 

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -1,0 +1,34 @@
+var assert = require('assert');
+var lodash = require('lodash');
+var objectAssign = require('./');
+
+var source1 = {a: 1, b: 2, c: 3};
+var source2 = {c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10, k: 11, l: 12, m: 13, n: 15, o: 15, p: 16};
+
+suite('object-assign', function () {
+	bench('small', function () {
+		objectAssign({foo: 0}, {bar: 1});
+	});
+
+	bench('default options', function () {
+		objectAssign({}, {foo: 0}, {foo: 1});
+	});
+
+	bench('big', function () {
+		objectAssign({}, source1, source2);
+	});
+});
+
+suite('lodash', function () {
+	bench('small', function () {
+		lodash.assign({foo: 0}, {bar: 1});
+	});
+
+	bench('default options', function () {
+		lodash.assign({}, {foo: 0}, {foo: 1});
+	});
+
+	bench('big', function () {
+		lodash.assign({}, source1, source2);
+	});
+});

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 function ToObject(val) {
 	if (val == null) {
@@ -9,29 +9,26 @@ function ToObject(val) {
 	return Object(val);
 }
 
-function ownEnumerableKeys(obj) {
-	var keys = Object.getOwnPropertyNames(obj);
-
-	if (Object.getOwnPropertySymbols) {
-		keys = keys.concat(Object.getOwnPropertySymbols(obj));
-	}
-
-	return keys.filter(function (key) {
-		return propIsEnumerable.call(obj, key);
-	});
-}
-
 module.exports = Object.assign || function (target, source) {
 	var from;
 	var keys;
 	var to = ToObject(target);
+	var symbols;
 
 	for (var s = 1; s < arguments.length; s++) {
-		from = arguments[s];
-		keys = ownEnumerableKeys(Object(from));
+		from = Object(arguments[s]);
 
-		for (var i = 0; i < keys.length; i++) {
-			to[keys[i]] = from[keys[i]];
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (Object.getOwnPropertySymbols) {
+			symbols = Object.getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				to[symbols[i]] = from[symbols[i]];
+			}
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "bench": "matcha bench.js"
   },
   "files": [
     "index.js"
@@ -33,6 +34,8 @@
     "browser"
   ],
   "devDependencies": {
+    "lodash": "^3.10.1",
+    "matcha": "^0.6.0",
     "mocha": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -72,6 +72,16 @@ it('should support `Object.create(null)` objects', function () {
 	assert.deepEqual(objectAssign({}, obj), {foo: true});
 });
 
+it('should preserve right properties order', function () {
+	var letters = 'abcdefghijklmnopqrst';
+	var source = {};
+	letters.split('').forEach(function (letter) {
+	    source[letter] = letter;
+	});
+	var target = objectAssign({}, source);
+	assert.equal(Object.keys(target).join(''), letters);
+});
+
 if (typeof Symbol !== 'undefined') {
 	it('should support symbol properties', function () {
 		var target = {};


### PR DESCRIPTION
Inspired by #20.

I inlined `ownEnumerableKeys` - because it was main bottleneck of performance (heavy `filter` and `keys` construction).

It can be better, than in lodash if we disable Symbols checking, but this will break specification (in NodeJS 0.10 it will be faster thou).

IoJS 3.0.0:

```
Before changes:

                      object-assign
         459,622 op/s » small
         236,813 op/s » default options
         136,718 op/s » big

After changes:

                      object-assign
       1,280,370 op/s » small
         651,416 op/s » default options
         238,518 op/s » big
```

In Node 0.10.38:

```
Before changes:

                      object-assign
         740,634 op/s » small
         336,369 op/s » default options
          76,365 op/s » big

After changes:

                      object-assign
       4,002,658 op/s » small
       1,418,239 op/s » default options
         170,629 op/s » big
```

Any comments appreciated.