### PR TITLE
Adding module support for Commonjs, AMD or Browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,39 +1,46 @@
 /* eslint-disable no-unused-vars */
 'use strict';
-var hasOwnProperty = Object.prototype.hasOwnProperty;
-var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+(function (name, definition, context, dependencies) {
+    if (typeof context['module'] !== 'undefined' && context['module']['exports']) { if (dependencies && context['require']) { for (var i = 0; i < dependencies.length; i++) context[dependencies[i]] = context['require'](dependencies[i]); } context['module']['exports'] = definition.apply(context); }
+    else if (typeof context['define'] !== 'undefined' && typeof context['define'] === 'function' && context['define']['amd']) { define(name, (dependencies || []), definition); }
+    else { context[name] = definition(); }
+})('objectAssign', function () {
+    var hasOwnProperty = Object.prototype.hasOwnProperty;
+    var propIsEnumerable = Object.prototype.propertyIsEnumerable;
 
-function toObject(val) {
-	if (val === null || val === undefined) {
-		throw new TypeError('Object.assign cannot be called with null or undefined');
-	}
+    function toObject(val) {
+        if (val === null || val === undefined) {
+            throw new TypeError('Object.assign cannot be called with null or undefined');
+        }
 
-	return Object(val);
-}
+        return Object(val);
+    }
 
-module.exports = Object.assign || function (target, source) {
-	var from;
-	var to = toObject(target);
-	var symbols;
+    return Object.assign || function (target, source) {
+        var from;
+        var to = toObject(target);
+        var symbols;
 
-	for (var s = 1; s < arguments.length; s++) {
-		from = Object(arguments[s]);
+        for (var s = 1; s < arguments.length; s++) {
+            from = Object(arguments[s]);
 
-		for (var key in from) {
-			if (hasOwnProperty.call(from, key)) {
-				to[key] = from[key];
-			}
-		}
+            for (var key in from) {
+                if (hasOwnProperty.call(from, key)) {
+                    to[key] = from[key];
+                }
+            }
 
-		if (Object.getOwnPropertySymbols) {
-			symbols = Object.getOwnPropertySymbols(from);
-			for (var i = 0; i < symbols.length; i++) {
-				if (propIsEnumerable.call(from, symbols[i])) {
-					to[symbols[i]] = from[symbols[i]];
-				}
-			}
-		}
-	}
+            if (Object.getOwnPropertySymbols) {
+                symbols = Object.getOwnPropertySymbols(from);
+                for (var i = 0; i < symbols.length; i++) {
+                    if (propIsEnumerable.call(from, symbols[i])) {
+                        to[symbols[i]] = from[symbols[i]];
+                    }
+                }
+            }
+        }
 
-	return to;
-};
+        return to;
+    };
+
+}, (this || {}));

--- a/index.js
+++ b/index.js
@@ -1,9 +1,21 @@
 /* eslint-disable no-unused-vars */
 'use strict';
 (function (name, definition, context, dependencies) {
-    if (typeof context['module'] !== 'undefined' && context['module']['exports']) { if (dependencies && context['require']) { for (var i = 0; i < dependencies.length; i++) context[dependencies[i]] = context['require'](dependencies[i]); } context['module']['exports'] = definition.apply(context); }
-    else if (typeof context['define'] !== 'undefined' && typeof context['define'] === 'function' && context['define']['amd']) { define(name, (dependencies || []), definition); }
-    else { context[name] = definition(); }
+    if (typeof context['module'] !== 'undefined' && context['module']['exports']) 
+    { 
+    	if (dependencies && context['require']) { 
+    		for (var i = 0; i < dependencies.length; i++) 
+    		context[dependencies[i]] = context['require'](dependencies[i]); 
+    	} 
+    	context['module']['exports'] = definition.apply(context); 
+    }
+    else if (typeof context['define'] !== 'undefined' && typeof context['define'] === 'function' && context['define']['amd']) 
+    { 
+    	define(name, (dependencies || []), definition); 
+    }
+    else { 
+    	context[name] = definition(); 
+    }
 })('objectAssign', function () {
     var hasOwnProperty = Object.prototype.hasOwnProperty;
     var propIsEnumerable = Object.prototype.propertyIsEnumerable;


### PR DESCRIPTION
Please take note that no change have been made to your code and your tests will pass just as before. But now this module can be used with either Commonjs module pattern or AMD. 

The code added is based on this SO question : 
http://stackoverflow.com/questions/13673346/supporting-both-commonjs-and-amd
  