### PR TITLE
Reduce bug checks to those that effect versions of Node with built-in `Object.assign`

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,38 +17,15 @@ function shouldUseNative() {
 			return false;
 		}
 
-		// Detect buggy property enumeration order in older V8 versions.
-
-		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
-		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
-		test1[5] = 'de';
-		if (Object.getOwnPropertyNames(test1)[0] === '5') {
-			return false;
-		}
-
+		// Detect buggy property enumeration order in Node v4.
 		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
-		var test2 = {};
-		for (var i = 0; i < 10; i++) {
-			test2['_' + String.fromCharCode(i)] = i;
-		}
-		var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
-			return test2[n];
+		var test = {};
+		var expected = 'abcdefghijklmnopqrst';
+		expected.split('').forEach(function (letter) {
+			test[letter] = letter;
 		});
-		if (order2.join('') !== '0123456789') {
-			return false;
-		}
 
-		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
-		var test3 = {};
-		'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
-			test3[letter] = letter;
-		});
-		if (Object.keys(Object.assign({}, test3)).join('') !==
-				'abcdefghijklmnopqrst') {
-			return false;
-		}
-
-		return true;
+		return Object.keys(Object.assign({}, test)).join('') === expected;
 	} catch (err) {
 		// We don't expect any of the above to throw, but better to be safe.
 		return false;


### PR DESCRIPTION
This PR reduces the bug checks to those that effect versions of Node with built-in `Object.assign`.
I used Node v4.0.0 as the minimum bar.

Related to [object-assign/pull/32/files](https://github.com/sindresorhus/object-assign/pull/32/files).

\cc @rgbkrk 