### PR TITLE
Avoid materializing the `arguments` object in Chakra.

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,9 +55,9 @@ function shouldUseNative() {
 	}
 }
 
-module.exports = shouldUseNative() ? Object.assign : function (target, source) {
+module.exports = shouldUseNative() ? Object.assign : function () {
 	var from;
-	var to = toObject(target);
+	var to = toObject(arguments[0]);
 	var symbols;
 
 	for (var s = 1; s < arguments.length; s++) {

--- a/test.js
+++ b/test.js
@@ -3,10 +3,6 @@ import test from 'ava';
 Object.assign = require('./');
 const objectAssign = require('./');
 
-test('have the correct length', t => {
-	t.is(objectAssign.length, 2);
-});
-
 test('throw when target is not an object', t => {
 	t.throws(() => {
 		objectAssign(null);


### PR DESCRIPTION
Unlike V8, Chakra will currently create the real, heavier, `arguments` object in the presence of formal parameters. This patch removes the formal params to keep things light.