### PR TITLE
Store a reference to `Object.getOwnPropertySymbols`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 /* eslint-disable no-unused-vars */
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 var propIsEnumerable = Object.prototype.propertyIsEnumerable;
 
@@ -69,8 +70,8 @@ module.exports = shouldUseNative() ? Object.assign : function (target, source) {
 			}
 		}
 
-		if (Object.getOwnPropertySymbols) {
-			symbols = Object.getOwnPropertySymbols(from);
+		if (getOwnPropertySymbols) {
+			symbols = getOwnPropertySymbols(from);
 			for (var i = 0; i < symbols.length; i++) {
 				if (propIsEnumerable.call(from, symbols[i])) {
 					to[symbols[i]] = from[symbols[i]];


### PR DESCRIPTION
For consistency with the other `Object` references used in the `assign` implementation
I moved `Object.getOwnPropertySymbols` to a variable reference.