### PR TITLE
Add built-in `Object.assign` benchmarks

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -26,6 +26,22 @@ var source2 = {
 	p: 16
 };
 
+if (Object.assign) {
+	suite('Object.assign', function () {
+		bench('small', function () {
+			Object.assign({foo: 0}, {bar: 1});
+		});
+
+		bench('default options', function () {
+			Object.assign({}, {foo: 0}, {foo: 1});
+		});
+
+		bench('big', function () {
+			Object.assign({}, source1, source2);
+		});
+	});
+}
+
 suite('object-assign', function () {
 	bench('small', function () {
 		objectAssign({foo: 0}, {bar: 1});

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "devDependencies": {
     "ava": "^0.16.0",
-    "lodash": "^4.8.2",
+    "lodash": "^4.16.4",
     "matcha": "^0.7.0",
     "xo": "*"
   }


### PR DESCRIPTION
This PR adds a benchmark for the built-on `Object.assign`.
Since `Object.assign` is not used by `object-assign` in Node v4 it gives a more complete picture.