### PR TITLE
Set main.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "xo && ava",
     "bench": "matcha bench.js"
   },
+  "main": "index.js",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
When using Webjar and webjar-locator, the main attribute in the package.json file is required to be able to provide the RequireJS configuration.