### PR TITLE
Remove `--save` in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ means, use `Object.assign()` instead of this package.
 ## Install
 
 ```
-$ npm install --save object-assign
+$ npm install object-assign
 ```
 
 


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358