### PR TITLE
Grab latest version of lodash to avoid the security vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "devDependencies": {
     "ava": "^0.16.0",
-    "lodash": "^4.16.4",
+    "lodash": "^4.17.13",
     "matcha": "^0.7.0",
     "xo": "^0.16.0"
   }


### PR DESCRIPTION
"CVE-2019-10744
More information
high severity
Vulnerable versions: < 4.17.13
Patched version: 4.17.13

Affected versions of lodash are vulnerable to Prototype Pollution.
The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload."

Please merge this in and make a new npm release. 🥇 