### PR TITLE
Adding Github Actions badge removed on #53

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# object-assign
+# object-assign [![Build Status](https://github.com/sindresorhus/object-assign/actions/workflows/main.yml/badge.svg)](https://github.com/sindresorhus/object-assign/actions)
 
 > ES2015 [`Object.assign()`](http://www.2ality.com/2014/01/object-assign.html) [ponyfill](https://ponyfill.com)
 


### PR DESCRIPTION
As the title mentions, I am adding the Github Actions badge removed on the repository on [#53](https://github.com/sindresorhus/object-assign/pull/53/files?file-filters%5B%5D=.md) when the migration from Travis CI to Github Actions was completed.